### PR TITLE
[FIX] : 추천 검색어, 방향키 이동 이슈 해결 및 검색어 재입력 시 focusIndex 리셋

### DIFF
--- a/src/components/SearchSection/SearchBar/index.tsx
+++ b/src/components/SearchSection/SearchBar/index.tsx
@@ -3,16 +3,16 @@ import DeleteButton from './DeleteButton';
 
 type SearchBarProps = {
   inputText: string;
-  setInputText: React.Dispatch<React.SetStateAction<string>>;
   isOnFocus: boolean;
   onSearch: (input: string) => void;
+  setInputText: React.Dispatch<React.SetStateAction<string>>;
 };
 
 function SearchBar({
   inputText,
-  setInputText,
   isOnFocus,
   onSearch,
+  setInputText,
 }: SearchBarProps) {
   const onInput = (event: React.FormEvent<HTMLInputElement>) => {
     setInputText(event.currentTarget.value);

--- a/src/components/SearchSection/SearchWordBox/SearchWord/index.tsx
+++ b/src/components/SearchSection/SearchWordBox/SearchWord/index.tsx
@@ -24,7 +24,7 @@ function SearchWord({
       <SearchIcon size="16" />
       <span className="text-black">
         {inputText ? <span className="font-bold">{inputText}</span> : null}
-        {word?.slice(inputText?.length)}
+        {word.slice(inputText?.length)}
       </span>
     </button>
   );

--- a/src/components/SearchSection/SearchWordBox/index.tsx
+++ b/src/components/SearchSection/SearchWordBox/index.tsx
@@ -1,25 +1,26 @@
-import { useState } from 'react';
 import { MAX_DISPLAYED, SUGGESTED_SEARCH_WORDS } from '@/constants/searchWord';
 import SearchWord from './SearchWord';
 
 type SearchWordBoxProps = {
   isLoading: boolean;
   inputText: string;
-  setInputText: React.Dispatch<React.SetStateAction<string>>;
+  debouncedInputText: string;
   recentSearchWords: string[];
-  onSearch: (input: string) => void;
   autocompleteWords: SearchWordType[];
   focusIndex: number;
+  onSearch: (input: string) => void;
+  setInputText: React.Dispatch<React.SetStateAction<string>>;
 };
 
 function SearchWordBox({
   isLoading,
   inputText,
-  setInputText,
+  debouncedInputText,
   recentSearchWords,
-  onSearch,
   autocompleteWords,
   focusIndex,
+  onSearch,
+  setInputText,
 }: SearchWordBoxProps) {
   const clickWord = (word: string) => {
     setInputText(word);
@@ -29,11 +30,13 @@ function SearchWordBox({
   return (
     <div className="absolute mt-1.5 py-6 w-full max-w-[486px] bg-white rounded-[1.2rem] shadow-lg left-[50%] translate-x-[-50%]">
       {inputText ? (
+        // 사용자가 검색어를 입력중일 때
         <>
           <SearchWord
             inputText={inputText}
             word={inputText}
             clickWord={clickWord}
+            isFocused={false}
           />
 
           <div className="px-6 py-1 text-[0.85rem] text-gray-400 leading-none">
@@ -44,11 +47,12 @@ function SearchWordBox({
               검색 중...
             </div>
           ) : autocompleteWords.length ? (
+            // 사용자가 검색중이고 추천 검색어가 있을 때
             <>
               {autocompleteWords.map(({ id, name }, index) => (
                 <SearchWord
                   key={id}
-                  inputText={inputText}
+                  inputText={debouncedInputText}
                   word={name}
                   clickWord={clickWord}
                   isFocused={focusIndex === index}
@@ -56,17 +60,19 @@ function SearchWordBox({
               ))}
             </>
           ) : (
+            // 추천 검색어가 없을 때
             <div className="px-6 py-2 text-gray-300">검색어 없음</div>
           )}
         </>
       ) : (
+        // 검색어 입력중이 아닐 때
         <>
           <div className="pb-6">
             <div className="px-6 text-[0.85rem] text-gray-400 leading-none">
               최근 검색어
             </div>
-
             {recentSearchWords.length ? (
+              // 최근 검색어가 있을 때
               <div className="flex flex-col pt-2">
                 {recentSearchWords
                   .slice(0, MAX_DISPLAYED)
@@ -80,6 +86,7 @@ function SearchWordBox({
                   ))}
               </div>
             ) : (
+              // 최근 검색어가 없을 때
               <div className="px-6  pt-5 text-gray-300">
                 최근 검색어가 없습니다
               </div>

--- a/src/components/SearchSection/index.tsx
+++ b/src/components/SearchSection/index.tsx
@@ -32,9 +32,10 @@ function SearchSection() {
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if (!isOnFocus) return;
+      if (e.isComposing) return;
 
       const currentData = autocompleteWords;
-      if (e.key === 'ArrowDown' && e.isComposing === false) {
+      if (e.key === 'ArrowDown') {
         e.preventDefault();
 
         setFocusIndex((currentIndex) =>

--- a/src/components/SearchSection/index.tsx
+++ b/src/components/SearchSection/index.tsx
@@ -98,7 +98,7 @@ function SearchSection() {
           setInputText={setInputText}
         />
 
-        <div ref={wordBoxRef} className={isOnFocus ? '' : 'opacity-0'}>
+        <div ref={wordBoxRef} className={isOnFocus ? '' : 'hidden'}>
           <SearchWordBox
             isLoading={isLoading}
             inputText={inputText}

--- a/src/components/SearchSection/index.tsx
+++ b/src/components/SearchSection/index.tsx
@@ -71,7 +71,7 @@ function SearchSection() {
       setIsLoading(true);
       const words = await searchAPI(debouncedInputText.trim());
       setIsLoading(false);
-      setFocusIndex(-1);
+      setFocusIndex(DEFAULT_INDEX);
       setAutocompleteWords(words.slice(0, MAX_DISPLAYED));
     };
 

--- a/src/components/SearchSection/index.tsx
+++ b/src/components/SearchSection/index.tsx
@@ -98,7 +98,7 @@ function SearchSection() {
           setInputText={setInputText}
         />
 
-        <div ref={wordBoxRef} className={isOnFocus ? '' : 'hidden'}>
+        <div ref={wordBoxRef} className={isOnFocus ? '' : 'opacity-0'}>
           <SearchWordBox
             isLoading={isLoading}
             inputText={inputText}

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -1,4 +1,4 @@
 export const BASE_URL = '/api/v1';
 export const API_URLS = { search: '/search-conditions/' };
 
-export const DEFAULT_INDEX = -2;
+export const DEFAULT_INDEX = -1;


### PR DESCRIPTION
## 🐣 개요

- 추천 검색어 받아온 이후 빠르게 입력하면 발생하는 이슈 해결
- 최초 다운키 입력시 두번 이벤트가 발생하는 이슈
- 검색어 재 입력시 focusIndex -1로 초기화

## 🐣 작업사항
- ### 추천 검색어 받아온 이후 빠르게 입력하면 발생하는 이슈 해결
추천 검색어가 생성이 된 후 빠르게 검색어를 다시 입력하면 추천 검색어에 현재 입력중인 input으로 나타나는 문제
```tsx
// components/SearchSection/SearchBox/index.tsx

            <>
              {autocompleteWords.map(({ id, name }, index) => (
                <SearchWord
                  key={id}
                  inputText={inputText}
                  word={name}
                  clickWord={clickWord}
                  isFocused={focusIndex === index}
                />
              ))}
            </>
``` 
추천 검색어가 있으면 map을 통해 `SearchWord` 컴포넌트에 props로 `inputText`를 전달해주고 있다

```tsx
// components/SearchSection/SearchBox/SearchWord/index.tsx

      <span className="text-black">
        {inputText ? <span className="font-bold">{inputText}</span> : null}
        {word?.slice(inputText?.length)}
      </span>
``` 
현재 입력중인 inputText값을 보여주고 있기 때문

따라서 현재 입력중인 inputText값이 아닌, debounced된 Text값을 보여주는 것으로 해결

```tsx
//  components/SearchSection/SearchBox/index.tsx

            <>
              {autocompleteWords.map(({ id, name }, index) => (
                <SearchWord
                  key={id}
                  inputText={debouncedInputText} // 전달하는 값을 debouncedInputText로 변경
                  word={name}
                  clickWord={clickWord}
                  isFocused={focusIndex === index}
                />
              ))}
            </>
``` 

- ### 최초 다운키 입력시 두번 이벤트가 발생하는 이슈 해결 (*정정수님 해결방안*)
추천검색어 리스트에 처음 아래 방향키 입력 시 두번 입력해야 하는 문제

> **IME composition**
> 
> 
> IME는 영어가 아닌 한글, 일본어, 중국어와 같은 언어를 다양한 브라우저에서 지원하도록 언어를 변환시켜주기 위한 OS 단계의 어플리케이션을 말한다.
> 
> 그러나 IME 과정에서 keydown 이벤트가 발생하면, OS와 브라우저에서 해당 이벤트를 모두 처리하기 때문에 keydown 이벤트가 중복으로 발생하게 되는 것이다.
> 
> `즉, IME를 통해 한글, 일본어, 중국어 등을 변환하는 과정(composition)에서 keydown 이벤트는 OS 뿐만 아니라 브라우저에서도 처리되기 때문에 중복 발생된다.`
>

> **isComposing**
> 
> 
> 이를 위해 Web API 스펙을 확인하며 event target에 KeyboardEvent.isComposing 이라는 프로퍼티를 제공한다. 자세한 설명을 보면, composition Session 중에 event가 발생하는지 여부를 불리언 값으로 반환한다고 명시되어 있다 
> 
> 즉, `한글 등 비영어권 언어를 표현하는 과정에서 이 값을 참조하면 true값을 반환`한다.
>

keydown 함수 조건식에 `e.isComposing === false` 추가

```tsx
// components/SearchSection/index.tsx

  const handleKeyDown = useCallback(
      ...
      if (e.key === 'ArrowDown' && e.isComposing === false) { // e.isComposing 조건 추가
        e.preventDefault();

        setFocusIndex((currentIndex) =>
          currentIndex === currentData.length - 1
            ? currentIndex
            : currentIndex + 1,
        );
      }
      ...
  );
``` 
이에 따른 constants DEFAULT_INDEX도 다시 -1로 수정

- ### SearchWord에 isFocused를 넘기지 않는 코드 수정

- ###  추천 검색어를 재입력시 focusIndex를 -1로 리셋하는 과정 추가
추천 검색어 리스트에서 키보드를 통해 인덱스 이동 후 다른 검색어를 입력시
새로 출력되는 추천 검색어 리스트에 자동으로 이전 인덱스가 표기되는 버그 수정.
inputText가 변할때마다 setFocusIndex를 하는 것이 아닌 `debouncedInputText가 수정될 때 setFocusIndex가 실행되도록 구성`

- ### `SearchWordBox` 컴포넌트의 중첩된 삼항연산자로 인한 코드 가독성 저하를 해결하기 위해 조건부 시작 부분에 주석으로 해당 조건에 대한 설명 추가

## 🐣 공유사항

참고자료: https://velog.io/@dosomething/React-%ED%95%9C%EA%B8%80-%EC%9E%85%EB%A0%A5%EC%8B%9C-keydown-%EC%9D%B4%EB%B2%A4%ED%8A%B8-%EC%A4%91%EB%B3%B5-%EB%B0%9C%EC%83%9D-%ED%98%84%EC%83%81
