### PR TITLE
포커스 스타일링 통일 및 검색 대소문자 이슈 해결

### DIFF
--- a/src/components/SearchSection/SearchWordBox/SearchWord/index.tsx
+++ b/src/components/SearchSection/SearchWordBox/SearchWord/index.tsx
@@ -1,18 +1,27 @@
 import SearchIcon from '@/components/SearchSection/SearchIcon';
+import { DEFAULT_INDEX } from '@/constants/config';
 
 type SearchWordProps = {
   inputText?: string;
   word: string;
   isFocused: boolean;
   onClick: (word: string) => void;
+  setFocusIndex: React.Dispatch<React.SetStateAction<number>>;
 };
 
-function SearchWord({ inputText, word, isFocused, onClick }: SearchWordProps) {
+function SearchWord({
+  inputText,
+  word,
+  isFocused,
+  onClick,
+  setFocusIndex,
+}: SearchWordProps) {
   return (
     <button
       type="button"
       onClick={() => onClick(word)}
-      className={`flex items-center gap-x-3 px-6 py-2 w-full text-gray-300 hover:bg-gray-50${
+      onMouseOver={() => setFocusIndex(DEFAULT_INDEX)}
+      className={`flex items-center gap-x-3 px-6 py-2 w-full text-gray-300 hover:bg-gray-50 focus:bg-gray-50${
         isFocused ? ' bg-gray-50' : ''
       }`}
     >

--- a/src/components/SearchSection/SearchWordBox/SearchWord/index.tsx
+++ b/src/components/SearchSection/SearchWordBox/SearchWord/index.tsx
@@ -18,7 +18,9 @@ function SearchWord({ inputText, word, isFocused, onClick }: SearchWordProps) {
     >
       <SearchIcon size="16" />
       <span className="text-black">
-        {inputText ? <span className="font-bold">{inputText}</span> : null}
+        {inputText && (
+          <span className="font-bold">{word.slice(0, inputText.length)}</span>
+        )}
         {word.slice(inputText?.length)}
       </span>
     </button>

--- a/src/components/SearchSection/SearchWordBox/index.tsx
+++ b/src/components/SearchSection/SearchWordBox/index.tsx
@@ -10,6 +10,7 @@ type SearchWordBoxProps = {
   focusIndex: number;
   onSearch: (input: string) => void;
   setInputText: React.Dispatch<React.SetStateAction<string>>;
+  setFocusIndex: React.Dispatch<React.SetStateAction<number>>;
 };
 
 function SearchWordBox({
@@ -21,6 +22,7 @@ function SearchWordBox({
   focusIndex,
   onSearch,
   setInputText,
+  setFocusIndex,
 }: SearchWordBoxProps) {
   const handleClickWord = (word: string) => {
     setInputText(word);
@@ -37,6 +39,7 @@ function SearchWordBox({
             word={inputText}
             onClick={handleClickWord}
             isFocused={false}
+            setFocusIndex={setFocusIndex}
           />
 
           <div className="px-6 py-1 text-[0.85rem] text-gray-400 leading-none">
@@ -56,6 +59,7 @@ function SearchWordBox({
                   word={name}
                   onClick={handleClickWord}
                   isFocused={focusIndex === index}
+                  setFocusIndex={setFocusIndex}
                 />
               ))}
             </>
@@ -82,6 +86,7 @@ function SearchWordBox({
                       word={word}
                       onClick={handleClickWord}
                       isFocused={focusIndex === index}
+                      setFocusIndex={setFocusIndex}
                     />
                   ))}
               </div>

--- a/src/components/SearchSection/index.tsx
+++ b/src/components/SearchSection/index.tsx
@@ -84,6 +84,7 @@ function SearchSection() {
             onSearch={handleSearch}
             autocompleteWords={autocompleteWords}
             focusIndex={focusIndex}
+            setFocusIndex={setFocusIndex}
           />
         </div>
       </div>

--- a/src/components/SearchSection/index.tsx
+++ b/src/components/SearchSection/index.tsx
@@ -45,7 +45,7 @@ function SearchSection() {
   useEffect(() => {
     const fetchAutocompleteWords = async () => {
       setIsLoading(true);
-      const words = await searchAPI(debouncedInputText.trim());
+      const words = await searchAPI(debouncedInputText.trim().toLowerCase());
       setIsLoading(false);
       setFocusIndex(DEFAULT_INDEX);
       setAutocompleteWords(words.slice(0, MAX_DISPLAYED));


### PR DESCRIPTION
#15 

## 🐣 개요

검색 대소문자 이슈 해결 및 포커스 스타일링 이슈 해결

## 🐣 작업사항

### 검색 대소문자 이슈 해결

- 검색어 소문자 입력 시 추천검색어 대문자가 소문자로 표시되는 이슈 해결
  - 기존에는 추천검색어 앞부분(입력한 검색어와 일치하는 부분)에 입력한 검색어를 그대로 보여주었으나, API 응답으로 받은 추천검색어를 그대로 보여주고 입력한 검색어와 일치하는 부분만 볼드체로 변경하여 보여주는 것으로 수정
    <img width="529" alt="image" src="https://user-images.githubusercontent.com/91963656/236457294-b67be5e9-84c4-49c0-a93c-c96fc8b659ed.png">

- 검색어 대문자로 입력 시에도 검색어 추천되도록 수정
  - `toLowerCase()` 추가하여 입력한 검색어를 소문자로 변환하여 API 요청하도록 수정

### 포커스 스타일링 이슈 해결
- CSS `focus` 속성 이용하여 `tab`키로 포커스 시에도 CSS 적용되도록 수정
  <img width="515" alt="image" src="https://user-images.githubusercontent.com/91963656/236459709-9e975211-82cb-41f2-819f-c22dbff5ea12.png">

- 방향키로 포커스하던 중 마우스오버로 포커스할 시 기존 방향키 포커스는 초기화되도록 수정