### PR TITLE
netlify 배포 proxy 추가

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+from = "/proxy/*"
+  to = "https://api.clinicaltrialskorea.com/:splat"  
+  status = 200
+  force = true

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -1,4 +1,5 @@
-export const BASE_URL = '/api/v1';
+const PROXY = window.location.hostname === 'localhost' ? '' : '/proxy';
+export const BASE_URL = `${PROXY}/api/v1`;
 export const API_URLS = { search: '/search-conditions/' };
 
 export const DEFAULT_INDEX = -1;


### PR DESCRIPTION
## 🐣 개요

- netlify 배포 API 이슈 해결: proxy 추가

## 🐣 작업사항

- base url에 proxy 추가
- `netlify.toml`에  proxy 추가